### PR TITLE
feat: Create SQLAlchemy URL from config

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -18,7 +18,19 @@ plugins:
     namespace: "target_postgres"
     pip_url: -e .
     config:
-      sqlalchemy_url: "postgresql://postgres:postgres@localhost:5432/postgres"
+      dialect: postgresql
+      driver_type: psycopg2
+      host: localhost
+      user: postgres
+      password: postgres
+      database: postgres
     settings:
-    - name: sqlalchemy_url
+    - name: dialect
+    - name: driver_type
+    - name: host
+    - name: port
+      kind: integer
+    - name: user
+    - name: password
       kind: password
+    - name: database

--- a/target_postgres/connector.py
+++ b/target_postgres/connector.py
@@ -1,5 +1,7 @@
 """Connector class for target."""
 import sqlalchemy
+from sqlalchemy.engine import URL
+
 from singer_sdk import SQLConnector
 
 
@@ -24,3 +26,36 @@ class PostgresConnector(SQLConnector):
             A newly created SQLAlchemy engine object.
         """
         return self.create_sqlalchemy_engine().connect()
+
+    def get_sqlalchemy_url(self, config: dict) -> str:
+        """Generates a SQLAlchemy URL for sqlbuzz.
+
+        Args:
+            config: The configuration for the connector.
+        """
+        if config['dialect'] == "postgresql" :
+            url_drivername:str = config['dialect']
+        else:
+            self.logger.error("Invalid dialect given")
+            exit(1)
+
+        if config['driver_type'] in ["psycopg2","pg8000","asyncpg","psycopg2cffi","pypostgresql","pygresql"]:
+            url_drivername += f"+{config['driver_type']}"
+        else:
+            self.logger.error("Invalid driver_type given")
+            exit(1)
+
+        self.logger.info(url_drivername)
+        config_url = URL.create(
+            url_drivername,
+            config['user'],
+            config['password'],
+            host = config['host'],
+            database = config['database']
+        )
+
+        if 'port' in config:
+            config_url.set(port={config['port']})
+        
+        return (config_url)
+        

--- a/target_postgres/target.py
+++ b/target_postgres/target.py
@@ -12,11 +12,39 @@ class TargetPostgres(Target):
     name = "target-postgres"
     config_jsonschema = th.PropertiesList(
         th.Property(
-            "sqlalchemy_url",
+            "dialect",
             th.StringType,
-            required=True,
-            description="SQLAlchemy connection string, example."
-            + "`postgresql://postgres:postgres@localhost:5432/postgres`",
+            description="The Dialect of SQLAlchamey"
+        ),
+        th.Property(
+            "driver_type",
+            th.StringType,
+            description="The Python Driver you will be using to connect to the SQL server"
+        ),
+        th.Property(
+            "host",
+            th.StringType,
+            description="The FQDN of the Host serving out the SQL Instance"
+        ),
+        th.Property(
+            "port",
+            th.IntegerType,
+            description="The port on which SQL awaiting connection"
+        ),
+        th.Property(
+            "user",
+            th.StringType,
+            description="The User Account who has been granted access to the SQL Server"
+        ),
+        th.Property(
+            "password",
+            th.StringType,
+            description="The Password for the User account"
+        ),
+        th.Property(
+            "database",
+            th.StringType,
+            description="The Default database for this connection"
         ),
     ).to_dict()
     default_sink_class = PostgresSink

--- a/target_postgres/tests/test_standard_target.py
+++ b/target_postgres/tests/test_standard_target.py
@@ -16,7 +16,14 @@ from singer_sdk.testing import (
 
 @pytest.fixture()
 def postgres_config():
-    return {"sqlalchemy_url": "postgresql://postgres:postgres@localhost:5432/postgres"}
+    return {
+        "dialect": "postgresql",
+        "driver_type": "psycopg2",
+        "host": "localhost",
+        "user": "postgres",
+        "password": "postgres",
+        "database": "postgres"  
+    }
 
 @pytest.fixture
 def postgres_target(postgres_config) -> TargetPostgres:


### PR DESCRIPTION
This is an attempt to satisfy the below feature that is mentioned in issue #4 

>  Host,Username,Port,Password,DBName, with SQL Alchemy having folks specify a url may be ok for now, it's the same thing. Seperate issue potentially