### PR TITLE
Update to target_schema instead of schema for config name

### DIFF
--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -220,4 +220,4 @@ class PostgresSink(SQLSink):
     @property
     def schema_name(self) -> str:
         """Schema to write to."""
-        return self.config["schema"]
+        return self.config["target_schema"]

--- a/target_postgres/target.py
+++ b/target_postgres/target.py
@@ -19,7 +19,7 @@ class TargetPostgres(Target):
             + "`postgresql://postgres:postgres@localhost:5432/postgres`",
         ),
         th.Property(
-            "schema",
+            "target_schema",
             th.StringType,
             required=True,
             description="Postgres schema to send data to, example: tap-clickup",

--- a/target_postgres/tests/test_standard_target.py
+++ b/target_postgres/tests/test_standard_target.py
@@ -19,7 +19,7 @@ from target_postgres.tests.samples.sample_tap_countries.countries_tap import (
 def postgres_config():
     return {
         "sqlalchemy_url": "postgresql://postgres:postgres@localhost:5432/postgres",
-        "schema": f"pytest_{str(uuid.uuid4()).replace('-','_')}",
+        "target_schema": f"pytest_{str(uuid.uuid4()).replace('-','_')}",
     }
 
 


### PR DESCRIPTION
Closes #37 
Went with target_schema as the config name as that's the canonical way to do this in singer https://docs.meltano.com/concepts/plugins#target_schema-extra 