### PR TITLE
fix: Add meltano to constraints file

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -84,10 +84,10 @@ jobs:
       python-version: "3.8"
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ env.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ env.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -90,7 +90,10 @@ jobs:
         python-version: ${{ env.python-version }}
     - name: Install dependencies
       run: |
+        pwd
         ls -lsa
+        ls .github -lsa
+        ls .github/workflows -lsa
         python -m pip install --upgrade pip
         pip install meltano
         meltano install

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -2,6 +2,9 @@ name: Test target-postgres
 
 on: [push]
 
+env:
+  PIP_CONSTRAINT: .github/workflows/constraints.txt
+  
 jobs:
   linting:
     runs-on: ubuntu-latest
@@ -17,8 +20,6 @@ jobs:
         python-version: '${{ matrix.python-version }}'
 
     - name: Install Poetry
-      env:
-        PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
         python -m pip install --upgrade pip
         pip install poetry
@@ -55,8 +56,6 @@ jobs:
       with:
         python-version: '${{ matrix.python-version }}'
     - name: Install Poetry
-      env:
-        PIP_CONSTRAINT: .github/workflows/constraints.txt
       run: |
         python -m pip install --upgrade pip
         pip install poetry

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -90,6 +90,7 @@ jobs:
         python-version: ${{ env.python-version }}
     - name: Install dependencies
       run: |
+        ls -lsa
         python -m pip install --upgrade pip
         pip install meltano
         meltano install

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,1 +1,2 @@
 poetry==1.3.2
+meltano==2.14.0


### PR DESCRIPTION
Had a failure crop up in the latest Meltano release `2.15.0` . It'd be nice to pin our target to a version of Meltano and get any errors like this in a Dependabot PR. 