### PR TITLE
ci: Install `meltano` using `pipx`

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install meltano
+        pipx install meltano
         meltano install
     - name: smoke-test-tap
       run: meltano run tap-smoke-test target-postgres


### PR DESCRIPTION
Seeing if this can be used a workaround for

```
No such file or directory: '/usr/bin/virtualenv'
```

seen in https://github.com/MeltanoLabs/target-postgres/actions/runs/4046145129/jobs/6958562915
