### PR TITLE
fix: Constrain SQLAlchemy to <2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1681,4 +1681,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "<3.12,>=3.7.1"
-content-hash = "b263bf970b11e8d60066af0dd794c16a4e76da7c866dfa6ebe00a37bd35539ed"
+content-hash = "9cfc5bb6faaba2cb1b473938489b9315ccf37d206f835af7d80c97255031fbaa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 name = "meltanolabs-target-postgres"
 version = "0.0.0"
 description = "`target-postgres` is a Singer target for Postgres, built with the Meltano SDK for Singer Targets."
-authors = ["Meltano Team and Contributors"]
-maintainers = ["Meltano Team and Contributors"]
+authors = ["Meltano Team and Contributors <hello@meltano.com>"]
+maintainers = ["Meltano Team and Contributors <hello@meltano.com>"]
 license = "MIT"
 readme = "README.md"
 homepage = "https://meltano.com"
@@ -35,6 +35,7 @@ python = "<3.12,>=3.7.1"
 requests = "^2.25.1"
 singer-sdk = "^0.28.0"
 psycopg2-binary = "2.9.6"
+sqlalchemy = "<2"
 sshtunnel = "0.4.0"
 
 [tool.poetry.dev-dependencies]
@@ -60,7 +61,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 # CLI declaration
 target-postgres = 'target_postgres.target:TargetPostgres.cli'
 
-[pytest]
+[tool.pytest.ini_options]
 pythonpath = [
   "."
 ]


### PR DESCRIPTION
The next release of the SDK adds support for SQLAlchemy 2.0 but this target does not seem to support it yet.

Related:

* https://github.com/MeltanoLabs/target-postgres/issues/87
