### PR TITLE
fix: Soft Delete Query

### DIFF
--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -358,8 +358,8 @@ class PostgresSink(SQLSink):
         query = sqlalchemy.text(
             f'UPDATE "{self.schema_name}"."{self.table_name}"\n'
             f"SET {self.soft_delete_column_name} = :deletedate \n"
-            f"WHERE {self.version_column_name} < :version "
-            f"OR {self.version_column_name} IS NULL \n"
+            f"WHERE ({self.version_column_name} < :version "
+            f"OR {self.version_column_name} IS NULL) \n"
             f"  AND {self.soft_delete_column_name} IS NULL\n"
         )
         query = query.bindparams(


### PR DESCRIPTION
Without the added parentheses, this was interpreted as `_sdc_table_version < $1 OR (_sdc_table_version IS NULL AND _sdc_deleted_at IS NULL)`, which was updating all non-null `_sdc_deleted_at` values to the latest date.