### PR TITLE
fix: Remove old code checking primary keys

### DIFF
--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -142,22 +142,14 @@ class PostgresSink(SQLSink):
 
         if self.append_only is False:
             insert_records: Dict[str, Dict] = {}  # pk : record
-            try:
-                for record in records:
-                    insert_record = {}
-                    for column in columns:
-                        insert_record[column.name] = record.get(column.name)
-                    primary_key_value = "".join(
-                        [str(record[key]) for key in primary_keys]
-                    )
-                    insert_records[primary_key_value] = insert_record
-            except KeyError:
-                raise RuntimeError(
-                    "Primary key not found in record. "
-                    f"full_table_name: {table.name}. "
-                    f"schema: {table.schema}.  "
-                    f"primary_keys: {primary_keys}."
-                )
+            for record in records:
+                insert_record = {}
+                for column in columns:
+                    insert_record[column.name] = record.get(column.name)
+                # No need to check for a KeyError here because the SDK already
+                # guaruntees that all key properties exist in the record.
+                primary_key_value = "".join([str(record[key]) for key in primary_keys])
+                insert_records[primary_key_value] = insert_record
             data_to_insert = list(insert_records.values())
         else:
             for record in records:

--- a/target_postgres/tests/test_standard_target.py
+++ b/target_postgres/tests/test_standard_target.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import jsonschema
 import pytest
 import sqlalchemy
+from singer_sdk.exceptions import MissingKeyPropertiesError
 from singer_sdk.testing import sync_end_to_end
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.types import TIMESTAMP, VARCHAR
@@ -217,7 +218,7 @@ def test_invalid_schema(postgres_target):
 
 
 def test_record_missing_key_property(postgres_target):
-    with pytest.raises(Exception) as e:
+    with pytest.raises(MissingKeyPropertiesError) as e:
         file_name = "record_missing_key_property.singer"
         singer_file_to_target(file_name, postgres_target)
     assert "Record is missing one or more key_properties." in str(e.value)


### PR DESCRIPTION
Remove dead code that checks for primary key because it's now handled by the SDK.

Switch to built-in MissingKeyPropertiesError for testing.

Closes #173 