### PR TITLE
fix: Use built-in RecordsWithoutSchemaException

### DIFF
--- a/target_postgres/target.py
+++ b/target_postgres/target.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 from pathlib import PurePath
 
-import jsonschema
 from singer_sdk import typing as th
-from singer_sdk.exceptions import RecordsWithoutSchemaException
 from singer_sdk.target_base import SQLTarget
 
 from target_postgres.sinks import PostgresSink
@@ -321,22 +319,3 @@ class TargetPostgres(SQLTarget):
         """
         # https://github.com/MeltanoLabs/target-postgres/issues/3
         return 1
-
-    def _process_record_message(self, message_dict: dict) -> None:
-        """Process a RECORD message.
-
-        Args:
-            message_dict: TODO
-        """
-        stream_name = message_dict["stream"]
-        if self.mapper.stream_maps.get(stream_name) is None:
-            raise RecordsWithoutSchemaException(
-                f"Schema message has not been sent for {stream_name}"
-            )
-        try:
-            super()._process_record_message(message_dict)
-        except jsonschema.exceptions.ValidationError as e:
-            self.logger.error(
-                f"Exception is being thrown for stream_name: {stream_name}"
-            )
-            raise e

--- a/target_postgres/target.py
+++ b/target_postgres/target.py
@@ -5,6 +5,7 @@ from pathlib import PurePath
 
 import jsonschema
 from singer_sdk import typing as th
+from singer_sdk.exceptions import RecordsWithoutSchemaException
 from singer_sdk.target_base import SQLTarget
 
 from target_postgres.sinks import PostgresSink
@@ -329,7 +330,9 @@ class TargetPostgres(SQLTarget):
         """
         stream_name = message_dict["stream"]
         if self.mapper.stream_maps.get(stream_name) is None:
-            raise Exception(f"Schema message has not been sent for {stream_name}")
+            raise RecordsWithoutSchemaException(
+                f"Schema message has not been sent for {stream_name}"
+            )
         try:
             super()._process_record_message(message_dict)
         except jsonschema.exceptions.ValidationError as e:

--- a/target_postgres/tests/test_standard_target.py
+++ b/target_postgres/tests/test_standard_target.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import jsonschema
 import pytest
 import sqlalchemy
-from singer_sdk.exceptions import RecordsWithoutSchemaException
 from singer_sdk.testing import sync_end_to_end
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.types import TIMESTAMP, VARCHAR
@@ -196,16 +195,6 @@ def test_aapl_to_postgres(postgres_config):
     tap = Fundamentals(config={}, state=None)
     target = TargetPostgres(config=postgres_config)
     sync_end_to_end(tap, target)
-
-
-def test_record_before_schema(postgres_target):
-    with pytest.raises(RecordsWithoutSchemaException) as e:
-        file_name = "record_before_schema.singer"
-        singer_file_to_target(file_name, postgres_target)
-
-    assert (
-        str(e.value) == "Schema message has not been sent for test_record_before_schema"
-    )
 
 
 def test_invalid_schema(postgres_target):

--- a/target_postgres/tests/test_standard_target.py
+++ b/target_postgres/tests/test_standard_target.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import jsonschema
 import pytest
 import sqlalchemy
+from singer_sdk.exceptions import RecordsWithoutSchemaException
 from singer_sdk.testing import sync_end_to_end
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.types import TIMESTAMP, VARCHAR
@@ -198,7 +199,7 @@ def test_aapl_to_postgres(postgres_config):
 
 
 def test_record_before_schema(postgres_target):
-    with pytest.raises(Exception) as e:
+    with pytest.raises(RecordsWithoutSchemaException) as e:
         file_name = "record_before_schema.singer"
         singer_file_to_target(file_name, postgres_target)
 


### PR DESCRIPTION
Instead of using a generic exception and relying on an error message, use the built-in RecordsWithoutSchemaException for when a record message arrives before its stream's schema message.

Closes #148 