### PR TITLE
doc: Datatype documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,69 @@ meltano invoke target-postgres --version
 
 See the [dev guide](https://sdk.meltano.com/en/latest/dev_guide.html) for more instructions on how to use the Meltano SDK to
 develop your own Singer taps and targets.
+
+## Data Types
+
+The below table shows how this tap will map between jsonschema datatypes and Postgres datatypes.
+
+| jsonschema                     | Postgres                                |
+|--------------------------------|-----------------------------------------|
+| integer                        | bigint                                  |
+| UNSUPPORTED                    | bigserial                               |
+| UNSUPPORTED                    | bit [ (n) ]                             |
+| UNSUPPORTED                    | bit varying [ (n) ]                     |
+| boolean                        | boolean                                 |
+| UNSUPPORTED                    | box                                     |
+| UNSUPPORTED                    | bytea                                   |
+| UNSUPPORTED                    | character [ (n) ]                       |
+| UNSUPPORTED                    | character varying [ (n) ]               |
+| UNSUPPORTED                    | cidr                                    |
+| UNSUPPORTED                    | circle                                  |
+| string with format="date"      | date                                    |
+| UNSUPPORTED                    | double precision                        |
+| UNSUPPORTED                    | inet                                    |
+| UNSUPPORTED                    | integer                                 |
+| UNSUPPORTED                    | interval [ fields ] [ (p) ]             |
+| UNSUPPORTED                    | json                                    |
+| array; object                  | jsonb                                   |
+| UNSUPPORTED                    | line                                    |
+| UNSUPPORTED                    | lseg                                    |
+| UNSUPPORTED                    | macaddr                                 |
+| UNSUPPORTED                    | macaddr8                                |
+| UNSUPPORTED                    | money                                   |
+| number                         | numeric [ (p, s) ]                      |
+| UNSUPPORTED                    | path                                    |
+| UNSUPPORTED                    | pg_lsn                                  |
+| UNSUPPORTED                    | pg_snapshot                             |
+| UNSUPPORTED                    | point                                   |
+| UNSUPPORTED                    | polygon                                 |
+| UNSUPPORTED                    | real                                    |
+| UNSUPPORTED                    | smallint                                |
+| UNSUPPORTED                    | smallserial                             |
+| UNSUPPORTED                    | serial                                  |
+| string without format; untyped | text                                    |
+| string with format="time"      | time [ (p) ] [ without time zone ]      |
+| UNSUPPORTED                    | time [ (p) ] with time zone             |
+| string with format="date-time" | timestamp [ (p) ] [ without time zone ] |
+| UNSUPPORTED                    | timestamp [ (p) ] with time zone        |
+| UNSUPPORTED                    | tsquery                                 |
+| UNSUPPORTED                    | tsvector                                |
+| UNSUPPORTED                    | txid_snapshot                           |
+| UNSUPPORTED                    | uuid                                    |
+| UNSUPPORTED                    | xml                                     |
+
+Note that while object types are mapped directly to jsonb, array types are mapped to a jsonb array.
+
+If a column has multiple jsonschema types, the following order is using to order Postgres types, from highest priority to lowest priority.
+- ARRAY(JSONB)
+- JSONB
+- TEXT
+- TIMESTAMP
+- DATETIME
+- DATE
+- TIME
+- DECIMAL
+- BIGINT
+- INTEGER
+- BOOLEAN
+- NOTYPE


### PR DESCRIPTION
README update that lists each postgres and jsonschema type and how target-postgres maps between them.

Based on prior discussion, this is all that's desired right now in-terms of #13 and #106, although this doesn't full address either.