### PR TITLE
fix: developer setup permissions on key files

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ pre-commit install
 
 ### Create and Run Tests
 
+Set up the SSL files permissions:
+
+```bash
+chmod 0600 .ssl/*.key
+```
+
+Start the test databases using Docker Compose:
+```bash
+docker-compose up -d
+```
+
 Create tests within the `target_postgres/tests` subfolder and
   then run:
 


### PR DESCRIPTION
I ran into this while running docker compose for the first time on a fresh install, I thought others might want to know about it