### PR TITLE
feat: Add data type mapping for UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The below table shows how this tap will map between jsonschema datatypes and Pos
 | UNSUPPORTED                    | tsquery                                 |
 | UNSUPPORTED                    | tsvector                                |
 | UNSUPPORTED                    | txid_snapshot                           |
-| UNSUPPORTED                    | uuid                                    |
+| string with format="uuid"      | uuid                                    |
 | UNSUPPORTED                    | xml                                     |
 
 Note that while object types are mapped directly to jsonb, array types are mapped to a jsonb array.

--- a/target_postgres/connector.py
+++ b/target_postgres/connector.py
@@ -16,7 +16,7 @@ import simplejson
 import sqlalchemy as sa
 from singer_sdk import SQLConnector
 from singer_sdk import typing as th
-from sqlalchemy.dialects.postgresql import ARRAY, BIGINT, BYTEA, JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, BIGINT, BYTEA, JSONB, UUID
 from sqlalchemy.engine import URL
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.types import (
@@ -287,6 +287,8 @@ class PostgresConnector(SQLConnector):
         # string formats
         if jsonschema_type.get("format") == "date-time":
             return TIMESTAMP()
+        if jsonschema_type.get("format") == "uuid":
+            return UUID()
         if (
             self.interpret_content_encoding
             and jsonschema_type.get("contentEncoding") == "base16"

--- a/target_postgres/connector.py
+++ b/target_postgres/connector.py
@@ -313,6 +313,7 @@ class PostgresConnector(SQLConnector):
             HexByteString,
             ARRAY,
             JSONB,
+            UUID,
             TEXT,
             TIMESTAMP,
             DATETIME,


### PR DESCRIPTION
I have a custom tap/extractor that outputs UUID identifiers with a schema Property like the following.

```python
from singer_sdk import typing as th

th.Property(
    "id",
    th.UUIDType,
)
```

I want to load the data into a PostgreSQL database with the `id` in a column with the [UUID type](https://www.postgresql.org/docs/current/datatype-uuid.html). This PR maps the [schema string type with format `uuid`](https://sdk.meltano.com/en/latest/classes/typing/singer_sdk.typing.UUIDType.html) to the PostgreSQL `uuid` type.