### PR TITLE
feat: As a last resort, try inserting TEXT into a UUID column

### DIFF
--- a/target_postgres/connector.py
+++ b/target_postgres/connector.py
@@ -558,7 +558,7 @@ class PostgresConnector(SQLConnector):
 
         if not self.allow_column_alter:
             # As a last resort, try inserting TEXT into a UUID column
-            if str(current_type) == 'UUID' and str(sql_type) == 'TEXT':
+            if str(current_type) == "UUID" and str(sql_type) == "TEXT":
                 return
 
             msg = (

--- a/target_postgres/connector.py
+++ b/target_postgres/connector.py
@@ -557,6 +557,10 @@ class PostgresConnector(SQLConnector):
             self.update_collation(compatible_sql_type, current_type_collation)
 
         if not self.allow_column_alter:
+            # As a last resort, try inserting TEXT into a UUID column
+            if str(current_type) == 'UUID' and str(sql_type) == 'TEXT':
+                return
+
             msg = (
                 "Altering columns is not supported. Could not convert column "
                 f"'{schema_name}.{table_name}.{column_name}' from '{current_type}' to "


### PR DESCRIPTION
Have some data that is of type UUID where the source treats it as text.

Instead of failing with an exception:
```
NotImplementedError: Altering columns is not supported. Could not convert column 'public.users.uuid' from 'UUID' to 'TEXT'.
```
Just treat them as compatible.

I couldn't think of a different way to do this, as even though the Postgres integration supports UUID, not all do. And technically UUID isn't TEXT (just that it's represented as text in sql, so the DB handles it transparently), so it shouldn't be part of `merge_sql_types`.