### PR TITLE
fix: Ensure variant `JSONB` output from tap-postgres is mapped to `JSONB` in this target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,14 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.2
+  rev: v0.5.4
   hooks:
   - id: ruff
     args: [--fix]
   - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v1.10.1'
+  rev: 'v1.11.0'
   hooks:
   - id: mypy
     exclude: tests

--- a/target_postgres/connector.py
+++ b/target_postgres/connector.py
@@ -291,13 +291,18 @@ class PostgresConnector(SQLConnector):
         if "object" in jsonschema_type["type"]:
             return JSONB()
         if "array" in jsonschema_type["type"]:
-            items_type = jsonschema_type.get("items")
-            if "string" == items_type:
+            items_type = jsonschema_type.get("items", {})
+            if isinstance(items_type, str):
+                items_type = [items_type]
+            elif "type" in items_type:
+                items_type = items_type["type"]
+
+            if "string" in items_type:
                 return ARRAY(TEXT())
-            if "integer" == items_type:
+            if "integer" in items_type:
                 return ARRAY(BIGINT())
             else:
-                return ARRAY(JSONB())
+                return JSONB()
 
         # string formats
         if jsonschema_type.get("format") == "date-time":

--- a/target_postgres/tests/data_files/jsonb_data.singer
+++ b/target_postgres/tests/data_files/jsonb_data.singer
@@ -1,0 +1,3 @@
+{"type":"SCHEMA", "stream":"test_jsonb_data", "key_properties":["id"], "schema":{"required":["id"], "type":"object", "properties":{"id":{"type":["integer"]},"event_data":{"type":["string","number","integer","array","object","boolean","null"]}}}}
+{"type":"RECORD","stream":"test_jsonb_data","record":{"id":1,"event_data":null,"time_extracted":"2024-07-27T12:24:43.774995+00:00"}}
+{"type":"RECORD","stream":"test_jsonb_data","record":{"id":2,"event_data":{"test":{"test_name":"test_value"}},"time_extracted":"2024-07-27T12:24:43.774995+00:00"}}

--- a/target_postgres/tests/test_target_postgres.py
+++ b/target_postgres/tests/test_target_postgres.py
@@ -423,6 +423,16 @@ def test_array_data(postgres_target):
     verify_data(postgres_target, "test_carts", 4, "id", row)
 
 
+def test_jsonb_data(postgres_target):
+    file_name = "jsonb_data.singer"
+    singer_file_to_target(file_name, postgres_target)
+    row = [
+        {"id": 1, "event_data": None},
+        {"id": 2, "event_data": {"test": {"test_name": "test_value"}}},
+    ]
+    verify_data(postgres_target, "test_jsonb_data", 2, "id", row)
+
+
 def test_encoded_string_data(postgres_target):
     """
     We removed NUL characters from the original encoded_strings.singer as postgres doesn't allow them.


### PR DESCRIPTION
fixes: #394 