### PR TITLE
feat: Improve interoperability with compatible databases and dialects (CrateDB)

### DIFF
--- a/target_postgres/connector.py
+++ b/target_postgres/connector.py
@@ -531,7 +531,7 @@ class PostgresConnector(SQLConnector):
             if picked_type is not None:
                 sql_type_array.append(picked_type)
 
-        return PostgresConnector.pick_best_sql_type(sql_type_array=sql_type_array)
+        return self.pick_best_sql_type(sql_type_array=sql_type_array)
 
     def pick_individual_type(self, jsonschema_type: dict):
         """Select the correct sql type assuming jsonschema_type has only a single type.


### PR DESCRIPTION
## Proposal
For better supporting databases largely compatible with PostgreSQL, this improvement makes it unneccessary to override the whole `to_sql_type(...)` method just to override the `pick_best_sql_type(...)` method on classes inheriting from `PostgresConnector`, like we are doing with `CrateDBConnector`.

## Background
We are currently trying to bring the `JSONSchemaToSQL` type mapping mechanics (kudos!) to [meltano-target-cratedb], and would like to get rid of as many customization boilerplate as possible.

[meltano-target-cratedb]: https://github.com/crate/meltano-target-cratedb
